### PR TITLE
Tighten lower bound on `base`

### DIFF
--- a/hslua-aeson.cabal
+++ b/hslua-aeson.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Scripting.Lua.Aeson
-  build-depends:       base                 >= 4.7     && < 5
+  build-depends:       base                 >= 4.8     && < 5
                      , aeson                >= 0.11    && < 1.2
                      , hashable             >= 1.2     && < 1.3
                      , hslua                >= 0.4     && < 0.5


### PR DESCRIPTION
Currently the package claims compat with base >= 4.7, however GHC 7.8.4 disagrees:

```
Configuring component lib from hslua-aeson-0.1.0.1...
Preprocessing library hslua-aeson-0.1.0.1...
[1 of 1] Compiling Scripting.Lua.Aeson ( src/Scripting/Lua/Aeson.hs, /tmp/matrix-worker/1490006015/dist-newstyle/build/x86_64-linux/ghc-7.8.4/hslua-aeson-0.1.0.1/build/Scripting/Lua/Aeson.o )

src/Scripting/Lua/Aeson.hs:47:37: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:53:32: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:64:38: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:79:40: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:80:40: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:81:40: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:87:39: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:91:37: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:96:42: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:142:21: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:150:23: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:158:23: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:158:32: Not in scope: ‘<$>’

src/Scripting/Lua/Aeson.hs:158:40: Not in scope: ‘<*>’
```